### PR TITLE
Fix: Exit screen cleanup & Enter screen cleanup & Fixed #13

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,25 +1,13 @@
 //Git Command
-use std::process::Command;
+use std::process::{Command, Output};
 use std::str;
-use std::io::Stdout;
-use crossterm::terminal::disable_raw_mode;
-use tui::{Terminal, backend::CrosstermBackend};
 
-pub fn git_clone(proj_name: &str, url: String,terminal : &mut Terminal<CrosstermBackend<Stdout>>){
+pub fn git_clone(proj_name: &str, url: String) -> Output {
     let output = Command::new("git")
         .arg("clone")
         .arg(url)
         .arg(proj_name)
         .output()
         .expect("failed to execute process");
-    disable_raw_mode().unwrap();
-    terminal.show_cursor().unwrap();
-    if output.status.success() {
-        println!("\nCloned {} successfully\n", &proj_name);
-    } else {
-        println!(
-            "\nError Encountered while cloning, {:?}",
-            str::from_utf8(&output.stderr)
-        );
-    }
+    output
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::sync::mpsc;
+use std::str;
 use std::thread;
 use std::time::{Duration, Instant};
 use tui::{
@@ -109,7 +110,23 @@ pub fn render_tui(key:String, proj_name: &str){
                                     .expect("there is always a selected template"),
                             )
                             .unwrap();
-                    command::git_clone(proj_name, selected_template.url.to_string(),&mut terminal);
+
+                    disable_raw_mode().unwrap();
+                    execute!(
+                            terminal.backend_mut(),
+                            LeaveAlternateScreen,
+                        ).unwrap();
+                    println!("\nCloning {}..\n", proj_name);
+                    let output = command::git_clone(proj_name, selected_template.url.to_string());
+                    terminal.show_cursor().unwrap();
+                    if output.status.success() {
+                            println!("\nCloned {} successfully\n", &proj_name);
+                        } else {
+                            println!(
+                                "\nError Encountered while cloning, {:?}",
+                                str::from_utf8(&output.stderr)
+                            );
+                        }
                     break;
                     }
                 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -12,7 +12,8 @@ use tui::{
 };
 use crossterm::{
     event::{self, Event as CEvent, KeyCode},
-    terminal::{disable_raw_mode, enable_raw_mode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode,EnterAlternateScreen, LeaveAlternateScreen},
 };
 
 use crate::models::enums;
@@ -22,7 +23,9 @@ use crate::command;
 
 pub fn render_tui(key:String, proj_name: &str){
     enable_raw_mode().expect("can run in raw mode");
-    
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen).unwrap();
+
     let (tx, rx) = mpsc::channel();
     let tick_rate = Duration::from_millis(200);
     thread::spawn(move || {
@@ -67,8 +70,11 @@ pub fn render_tui(key:String, proj_name: &str){
         match rx.recv().unwrap() {
             enums::Event::Input(event) => match event.code {
                 KeyCode::Char('q') => {
-                    println!("{:?}", template_list_state.selected());
                     disable_raw_mode().unwrap();
+                    execute!(
+                        terminal.backend_mut(),
+                        LeaveAlternateScreen,
+                    ).unwrap();
                     terminal.show_cursor().unwrap();
                     break;
                 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,12 @@
 use std::io;
-use std::sync::mpsc;
 use std::str;
 use std::thread;
+use crate::search;
+use crate::command;
+use std::sync::mpsc;
+use std::io::Write;
+use crate::parse_json;
+use crate::models::enums;
 use std::time::{Duration, Instant};
 use tui::{
     backend::CrosstermBackend,
@@ -17,10 +22,6 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode,EnterAlternateScreen, LeaveAlternateScreen},
 };
 
-use crate::models::enums;
-use crate::parse_json;
-use crate::search;
-use crate::command;
 
 pub fn render_tui(key:String, proj_name: &str){
     enable_raw_mode().expect("can run in raw mode");
@@ -122,10 +123,7 @@ pub fn render_tui(key:String, proj_name: &str){
                     if output.status.success() {
                             println!("\nCloned {} successfully\n", &proj_name);
                         } else {
-                            println!(
-                                "\nError Encountered while cloning, {:?}",
-                                str::from_utf8(&output.stderr)
-                            );
+                            io::stderr().write_all(&output.stderr).unwrap();
                         }
                     break;
                     }


### PR DESCRIPTION
Fixed q key where it now exits the alternate screen (added alternate screen for the purpose of TUI) and enter key clears up the TUI screen as well and prints Cloning message. 
(also refactored command.rs to return the output and not handle any TUI commands)