### PR TITLE
refractor: moved app state into App struct and optimized search

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,41 @@
+use std::vec::Vec;
+use crate::models::structs::Submodule;
+use crate::search::perform_search;
+
+pub struct App {
+    pub submodules: Vec<Submodule>,
+    pub filtered_submodules: Vec<Submodule>,
+    pub last_query: Option<String>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        App {
+            filtered_submodules: vec![],
+            submodules: vec![],
+
+            last_query: None,
+        }
+    }
+}
+
+impl App {
+    pub fn new(submodules: Vec<Submodule>) -> Self {
+        App {
+            submodules,
+            ..App::default()
+        }
+    }
+
+    // Performs search on submodules and updates app's internal
+    // cached search. Only performs the search if it's needed.
+    pub fn search(&mut self, query: &str) {
+        // TODO: Process query to extract tags and name searches
+        if self.last_query.is_none() || query != self.last_query.as_deref().unwrap() {
+
+            self.filtered_submodules = perform_search(&self.submodules, query).expect("can search through submodules"); 
+
+            self.last_query = Some(query.to_string());
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod command;
 mod models;
 mod search;
 mod tui;
+mod app;
 
 const SUBMODULES_URL: &str =
     "https://api.github.com/repos/IEEE-VIT/templa-rs/contents/submodules.json";
@@ -47,6 +48,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    tui::render_tui(key, &proj, &submodules);
+    tui::render_tui(key, &proj, submodules);
     Ok(())
 }

--- a/src/models/structs.rs
+++ b/src/models/structs.rs
@@ -6,3 +6,15 @@ pub struct Submodule {
     pub url: String,
     pub tags: Vec<String>,
 }
+
+impl Submodule {
+    pub fn has_tag(&self, tag: &str) -> bool {
+        for t in self.tags.iter() {
+            if t == tag {
+                return true;
+            }
+        }
+
+        false
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,11 +3,12 @@ use crate::models::structs;
 
 pub fn perform_search(
     submodules: &[structs::Submodule],
-    key: String,
+    key: &str
 ) -> Result<Vec<structs::Submodule>, enums::Error> {
     let mut filtered_sm = vec![];
+
     for submodule in submodules.iter() {
-        if submodule.tags.contains(&key) {
+        if key.is_empty() || submodule.has_tag(key) {
             filtered_sm.push(submodule.clone());
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,6 @@
 use crate::command;
 use crate::models::{enums, structs::Submodule};
-use crate::search;
+use crate::app::App;
 use crossterm::{
     event::{self, Event as CEvent, KeyCode},
     execute,
@@ -21,10 +21,13 @@ use tui::{
     Terminal,
 };
 
-pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
+pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
     enable_raw_mode().expect("can run in raw mode");
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).unwrap();
+
+    // App state container
+    let mut app = App::new(submodules);
 
     let (tx, rx) = mpsc::channel();
     let tick_rate = Duration::from_millis(200);
@@ -56,6 +59,8 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
     template_list_state.select(Some(0));
 
     loop {
+        app.search(&key);
+
         terminal
             .draw(|rect| {
                 let size = rect.size();
@@ -64,7 +69,8 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                     .margin(2)
                     .constraints([Constraint::Percentage(80)].as_ref())
                     .split(size);
-                let template_list = render_templates(key.clone(), submodules);
+
+                let template_list = render_template_list(&app.filtered_submodules);
                 rect.render_stateful_widget(template_list, chunks[0], &mut template_list_state);
             })
             .unwrap();
@@ -79,7 +85,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                 }
                 KeyCode::Down => {
                     if let Some(selected) = template_list_state.selected() {
-                        let templates_length = submodules.len();
+                        let templates_length = app.filtered_submodules.len();
                         if selected >= templates_length - 1 {
                             template_list_state.select(Some(0));
                         } else {
@@ -89,7 +95,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                 }
                 KeyCode::Up => {
                     if let Some(selected) = template_list_state.selected() {
-                        let templates_length = submodules.len();
+                        let templates_length = app.filtered_submodules.len();
                         if selected > 0 {
                             template_list_state.select(Some(selected - 1));
                         } else {
@@ -99,8 +105,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                 }
                 KeyCode::Enter => {
                     if let Some(_) = template_list_state.selected() {
-                        let templates = search::perform_search(submodules, key.clone())
-                            .expect("can fetch template list");
+                        let templates = &app.filtered_submodules;
                         let selected_template = templates
                             .get(
                                 template_list_state
@@ -130,15 +135,14 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
     }
 }
 
-fn render_templates<'a>(key: String, submodules: &[Submodule]) -> List<'a> {
+fn render_template_list<'a>(filtered_submodules: &[Submodule]) -> List<'a> {
     let pets = Block::default()
         .borders(Borders::ALL)
         .style(Style::default().fg(Color::White))
         .title("Available Templates")
         .border_type(BorderType::Plain);
 
-    let filtered_template_list = search::perform_search(submodules, key).expect("can filter json");
-    let items: Vec<_> = filtered_template_list
+    let items: Vec<_> = filtered_submodules
         .iter()
         .map(|submodule| {
             ListItem::new(Spans::from(vec![Span::styled(


### PR DESCRIPTION
I created a new App struct to store the app's current state in. This makes the code a little bit cleaner, as it separates the app's state from the drawing logic.
With this change, the search feature has been optimized: now it caches the results in the app struct, and it performs new searches if and only if it needs to (For now, it searches only once, but this will become more relevant once we add a search bar). 
Also, by doing this i fixed the fact that on empty searches nothing was shown (now it shows every possible template), and the broken wrap around when a user tries to go up at index zero in the list, or down at the last index (previously, the cursor would disappear, and the program would crash if you pressed Enter).

All these changes will help to create further menus more easily, as now you can potentially track what menu you're in directly inside the app status.