### PR TITLE
feat: added live search bar

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -3,6 +3,11 @@ version: "1.0.0"
 author: IEEE-VIT. <contact@ieeevit.org>
 about: Solves all boilerplate template needs!
 args:
+    - first-query:
+        short: q
+        long: query
+        help: Specify the first query to search
+        takes_value: true
     - template-type:
         short: t
         long: type

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,16 @@
 use std::vec::Vec;
 use crate::models::structs::Submodule;
 use crate::search::perform_search;
+use tui::style::Color;
 
 pub struct App {
     pub submodules: Vec<Submodule>,
     pub filtered_submodules: Vec<Submodule>,
     pub last_query: Option<String>,
+
+    pub current_query: String,
+    
+    pub skin_color: Color,
 }
 
 impl Default for App {
@@ -14,28 +19,42 @@ impl Default for App {
             filtered_submodules: vec![],
             submodules: vec![],
 
+            current_query: String::new(),
             last_query: None,
+            skin_color: Color::Rgb(244, 71, 2)
         }
     }
 }
 
 impl App {
-    pub fn new(submodules: Vec<Submodule>) -> Self {
+    pub fn new(submodules: Vec<Submodule>, first_query: &str) -> Self {
         App {
             submodules,
+            current_query: first_query.to_string(),
             ..App::default()
         }
     }
 
     // Performs search on submodules and updates app's internal
     // cached search. Only performs the search if it's needed.
-    pub fn search(&mut self, query: &str) {
+    pub fn search(&mut self) {
         // TODO: Process query to extract tags and name searches
-        if self.last_query.is_none() || query != self.last_query.as_deref().unwrap() {
+        if self.last_query.is_none() || self.current_query != self.last_query.as_deref().unwrap() {
+            let mut final_query = vec![];
+            let mut tags = vec![];
 
-            self.filtered_submodules = perform_search(&self.submodules, query).expect("can search through submodules"); 
+            for token in self.current_query.split(' ') {
+                if let Some(tag_name) = token.strip_prefix("tag:") {
+                    tags.push(tag_name);
+                } else {
+                    final_query.push(token);
+                }
+            }
 
-            self.last_query = Some(query.to_string());
+
+            self.filtered_submodules = perform_search(&self.submodules, &final_query.join(" "), &tags).expect("can search through submodules"); 
+
+            self.last_query = Some(self.current_query.clone());
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,41 @@
+use std::vec::Vec;
+use crate::models::structs::Submodule;
+use crate::search::perform_search;
+
+pub struct App {
+    pub submodules: Vec<Submodule>,
+    pub filtered_submodules: Vec<Submodule>,
+    pub last_query: Option<String>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        App {
+            filtered_submodules: vec![],
+            submodules: vec![],
+
+            last_query: None,
+        }
+    }
+}
+
+impl App {
+    pub fn new(submodules: Vec<Submodule>) -> Self {
+        App {
+            submodules,
+            ..App::default()
+        }
+    }
+
+    // Performs search on submodules and updates app's internal
+    // cached search. Only performs the search if it's needed.
+    pub fn search(&mut self, query: &str) {
+        // TODO: Process query to extract tags and name searches
+        if self.last_query.is_none() || query != self.last_query.as_deref().unwrap() {
+
+            self.filtered_submodules = perform_search(&self.submodules, query).expect("can search through submodules"); 
+
+            self.last_query = Some(query.to_string());
+        }
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -19,7 +19,7 @@ pub fn git_clone(proj_name: &str, url: String) -> Result<Repository, Error> {
 
     cb.transfer_progress(|stats| {
         let percentage_done = (stats.received_bytes() / 1000000) as f64  / (repo_size / 1000)  as f64;
-        progress_bar.set_progression((percentage_done * 100 as f64) as usize);
+        progress_bar.set_progression((percentage_done * 100.0) as usize);
         true
     });
 
@@ -28,9 +28,9 @@ pub fn git_clone(proj_name: &str, url: String) -> Result<Repository, Error> {
     let repo = RepoBuilder::new()
         .fetch_options(fo)
         .clone(&url, Path::new(&proj_name));
-    match repo {
-        Ok(_) => progress_bar.set_progression(100),
-        Err(_) => {}
-    };
+
+    if repo.is_ok() {
+        progress_bar.set_progression(100);
+    }
     repo
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod command;
 mod models;
 mod search;
 mod tui;
+mod app;
 
 const SUBMODULES_URL: &str =
     "https://api.github.com/repos/IEEE-VIT/templa-rs/contents/submodules.json";
@@ -47,6 +48,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    tui::render_tui(key, &proj, &submodules);
+    tui::render_tui(key, &proj, submodules);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,8 @@ fn fetch_submodules() -> Result<Vec<models::structs::Submodule>, Box<dyn std::er
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let yaml = load_yaml!("../commands.yml");
     let matches = App::from(yaml).get_matches();
-    let mut key = String::new();
     let mut proj = String::new();
-    if let Some(template_name) = matches.value_of("template-type") {
-        key = String::from(template_name);
-    }
+
     if let Some(proj_name) = matches.value_of("name") {
         proj = String::from(proj_name);
     }
@@ -49,6 +46,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    tui::render_tui(key, &proj, submodules);
+    tui::render_tui(&proj, submodules, matches.value_of("first-query"), matches.value_of("template-type"));
     Ok(())
 }

--- a/src/models/structs.rs
+++ b/src/models/structs.rs
@@ -8,10 +8,12 @@ pub struct Submodule {
 }
 
 impl Submodule {
-    pub fn has_tag(&self, tag: &str) -> bool {
-        for t in self.tags.iter() {
-            if t == tag {
-                return true;
+    pub fn has_one_of_tags(&self, tags: &[&str]) -> bool {
+        for own_t in self.tags.iter() {
+            for t in tags.iter() {
+                if own_t == t {
+                    return true;
+                }
             }
         }
 

--- a/src/models/structs.rs
+++ b/src/models/structs.rs
@@ -6,3 +6,15 @@ pub struct Submodule {
     pub url: String,
     pub tags: Vec<String>,
 }
+
+impl Submodule {
+    pub fn has_tag(&self, tag: &str) -> bool {
+        for t in self.tags.iter() {
+            if t == tag {
+                return true;
+            }
+        }
+
+        false
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,12 +3,15 @@ use crate::models::structs;
 
 pub fn perform_search(
     submodules: &[structs::Submodule],
-    key: &str
+    name_query: &str,
+    tags: &[&str]
 ) -> Result<Vec<structs::Submodule>, enums::Error> {
     let mut filtered_sm = vec![];
+    let lowercase_query = name_query.to_lowercase();
 
     for submodule in submodules.iter() {
-        if key.is_empty() || submodule.has_tag(key) {
+        if (tags.is_empty() || submodule.has_one_of_tags(tags)) && 
+            (name_query.is_empty() || submodule.name.to_lowercase().contains(&lowercase_query)) {
             filtered_sm.push(submodule.clone());
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,11 +3,12 @@ use crate::models::structs;
 
 pub fn perform_search(
     submodules: &[structs::Submodule],
-    key: String,
+    key: &str
 ) -> Result<Vec<structs::Submodule>, enums::Error> {
     let mut filtered_sm = vec![];
+
     for submodule in submodules.iter() {
-        if submodule.tags.contains(&key) {
+        if key.is_empty() || submodule.has_tag(key) {
             filtered_sm.push(submodule.clone());
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,7 +2,7 @@ use crate::command;
 use crate::models::{enums, structs::Submodule};
 use crate::app::App;
 use crossterm::{
-    event::{self, Event as CEvent, KeyCode},
+    event::{self, Event as CEvent, KeyCode, KeyModifiers},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -15,18 +15,30 @@ use tui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
-    widgets::{Block, BorderType, Borders, List, ListItem, ListState},
+    text::{Span, Spans, Text},
+    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph},
     Terminal,
 };
 
-pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
+pub fn render_tui(proj_name: &str, submodules: Vec<Submodule>, optional_first_query: Option<&str>, optional_tag: Option<&str>,) {
     enable_raw_mode().expect("can run in raw mode");
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).unwrap();
 
     // App state container
-    let mut app = App::new(submodules);
+    let mut full_first_query = String::new();
+    
+    if let Some(tag_raw) = optional_tag {
+        full_first_query.push_str("tag:");
+        full_first_query.push_str(tag_raw);
+        full_first_query.push(' ');
+    }
+    
+    if let Some(first_query) = optional_first_query {
+        full_first_query.push_str(first_query);
+    }
+
+    let mut app = App::new(submodules, &full_first_query);
 
     let (tx, rx) = mpsc::channel();
     let tick_rate = Duration::from_millis(200);
@@ -43,10 +55,8 @@ pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
                 }
             }
 
-            if last_tick.elapsed() >= tick_rate {
-                if let Ok(_) = tx.send(enums::Event::Tick) {
-                    last_tick = Instant::now();
-                }
+            if last_tick.elapsed() >= tick_rate && tx.send(enums::Event::Tick).is_ok() {
+    	        last_tick = Instant::now();
             }
         }
     });
@@ -58,7 +68,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
     template_list_state.select(Some(0));
 
     loop {
-        app.search(&key);
+        app.search();
 
         terminal
             .draw(|rect| {
@@ -66,23 +76,43 @@ pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(2)
-                    .constraints([Constraint::Percentage(80)].as_ref())
+                    .constraints(
+                        [
+                            Constraint::Percentage(15),
+                            Constraint::Percentage(80),
+                        ].as_ref()
+                    )
                     .split(size);
 
-                let template_list = render_template_list(&app.filtered_submodules);
-                rect.render_stateful_widget(template_list, chunks[0], &mut template_list_state);
+                let template_list = render_template_list(&app.filtered_submodules, app.skin_color);
+                let template_search = render_search_bar(&app.current_query, app.skin_color);
+
+                rect.render_widget(template_search, chunks[0]);
+                rect.render_stateful_widget(template_list, chunks[1], &mut template_list_state);
             })
             .unwrap();
 
         match rx.recv().unwrap() {
-            enums::Event::Input(event) => match event.code {
-                KeyCode::Char('q') => {
+            enums::Event::Input(event) => match (event.code, event.modifiers) {
+                (KeyCode::Char(key), KeyModifiers::NONE) => {
+                    app.current_query.push(key);
+                }
+                (KeyCode::Char(key), KeyModifiers::SHIFT) => {
+                    app.current_query.push(key.to_ascii_uppercase());
+                }
+                (KeyCode::Backspace, KeyModifiers::NONE) => {
+                    app.current_query.pop();
+                }
+                (KeyCode::Backspace, KeyModifiers::CONTROL) => {
+                    app.current_query.clear();
+                }
+                (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                     disable_raw_mode().unwrap();
                     execute!(terminal.backend_mut(), LeaveAlternateScreen,).unwrap();
                     terminal.show_cursor().unwrap();
                     break;
                 }
-                KeyCode::Down => {
+                (KeyCode::Down, _) => {
                     if let Some(selected) = template_list_state.selected() {
                         let templates_length = app.filtered_submodules.len();
                         if selected >= templates_length - 1 {
@@ -92,7 +122,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
                         }
                     }
                 }
-                KeyCode::Up => {
+                (KeyCode::Up, _) => {
                     if let Some(selected) = template_list_state.selected() {
                         let templates_length = app.filtered_submodules.len();
                         if selected > 0 {
@@ -102,8 +132,8 @@ pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
                         }
                     }
                 }
-                KeyCode::Enter => {
-                    if let Some(_) = template_list_state.selected() {
+                (KeyCode::Enter, _) => {
+                    if template_list_state.selected().is_some() {
                         let templates = &app.filtered_submodules;
                         let selected_template = templates
                             .get(
@@ -137,11 +167,28 @@ pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
     }
 }
 
-fn render_template_list<'a>(filtered_submodules: &[Submodule]) -> List<'a> {
+fn render_search_bar(search_query: &str, skin_color: Color) -> Paragraph {
+    let mut search_content = String::new();
+    search_content.push_str(" / ");
+    search_content.push_str(search_query);
+
+    Paragraph::new(Text::from(search_content)).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .style(Style::default().fg(skin_color))
+    ).style(Style::default().fg(Color::White))
+}
+
+fn render_template_list<'a>(filtered_submodules: &[Submodule], skin_color: Color) -> List<'a> {
+    let title_span = Span::styled(
+        " Available Templates ",
+        Style::default().fg(skin_color).add_modifier(Modifier::BOLD)
+    );
+
     let pets = Block::default()
         .borders(Borders::ALL)
-        .style(Style::default().fg(Color::White))
-        .title("Available Templates")
+        .style(Style::default().fg(skin_color))
+        .title(title_span)
         .border_type(BorderType::Plain);
 
     let items: Vec<_> = filtered_submodules
@@ -149,7 +196,7 @@ fn render_template_list<'a>(filtered_submodules: &[Submodule]) -> List<'a> {
         .map(|submodule| {
             ListItem::new(Spans::from(vec![Span::styled(
                 submodule.name.clone(),
-                Style::default(),
+                Style::default().fg(Color::White),
             )]))
         })
         .collect();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,6 @@
 use crate::command;
 use crate::models::{enums, structs::Submodule};
-use crate::search;
+use crate::app::App;
 use crossterm::{
     event::{self, Event as CEvent, KeyCode},
     execute,
@@ -21,10 +21,13 @@ use tui::{
     Terminal,
 };
 
-pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
+pub fn render_tui(key: String, proj_name: &str, submodules: Vec<Submodule>) {
     enable_raw_mode().expect("can run in raw mode");
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).unwrap();
+
+    // App state container
+    let mut app = App::new(submodules);
 
     let (tx, rx) = mpsc::channel();
     let tick_rate = Duration::from_millis(200);
@@ -56,6 +59,8 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
     template_list_state.select(Some(0));
 
     loop {
+        app.search(&key);
+
         terminal
             .draw(|rect| {
                 let size = rect.size();
@@ -64,7 +69,8 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                     .margin(2)
                     .constraints([Constraint::Percentage(80)].as_ref())
                     .split(size);
-                let template_list = render_templates(key.clone(), submodules);
+
+                let template_list = render_template_list(&app.filtered_submodules);
                 rect.render_stateful_widget(template_list, chunks[0], &mut template_list_state);
             })
             .unwrap();
@@ -79,7 +85,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                 }
                 KeyCode::Down => {
                     if let Some(selected) = template_list_state.selected() {
-                        let templates_length = submodules.len();
+                        let templates_length = app.filtered_submodules.len();
                         if selected >= templates_length - 1 {
                             template_list_state.select(Some(0));
                         } else {
@@ -89,7 +95,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                 }
                 KeyCode::Up => {
                     if let Some(selected) = template_list_state.selected() {
-                        let templates_length = submodules.len();
+                        let templates_length = app.filtered_submodules.len();
                         if selected > 0 {
                             template_list_state.select(Some(selected - 1));
                         } else {
@@ -99,8 +105,7 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
                 }
                 KeyCode::Enter => {
                     if let Some(_) = template_list_state.selected() {
-                        let templates = search::perform_search(submodules, key.clone())
-                            .expect("can fetch template list");
+                        let templates = &app.filtered_submodules;
                         let selected_template = templates
                             .get(
                                 template_list_state
@@ -130,15 +135,14 @@ pub fn render_tui(key: String, proj_name: &str, submodules: &[Submodule]) {
     }
 }
 
-fn render_templates<'a>(key: String, submodules: &[Submodule]) -> List<'a> {
+fn render_template_list<'a>(filtered_submodules: &[Submodule]) -> List<'a> {
     let pets = Block::default()
         .borders(Borders::ALL)
         .style(Style::default().fg(Color::White))
         .title("Available Templates")
         .border_type(BorderType::Plain);
 
-    let filtered_template_list = search::perform_search(submodules, key).expect("can filter json");
-    let items: Vec<_> = filtered_template_list
+    let items: Vec<_> = filtered_submodules
         .iter()
         .map(|submodule| {
             ListItem::new(Spans::from(vec![Span::styled(


### PR DESCRIPTION
I've added a live search bar: if you type in it, the results shown will be filtered by what you write. By default, it filters by name. If you type `tag:TAGNAME`, separated by a whitespace, it filters all results by that tag (e.g., if you type `php tag:backend`, as of now it will show only basic-php-project-structure. It also works as `tag:backend php`, order does not matter).
As a result of this, to close the program now you type Control-C, not q anymore (As it is used by the search bar). If you give it multiple tags, it searches every entry that has at least one of them.
Also, the `-t TAGNAME` command now adds `tag:TAGNAME` as the first query, while a new `-q QUERY` command searches for `QUERY` at the start.
To improve on this, in the future maybe we can implement a cursor.