### PR TITLE
fix: invalid version 0 on git_proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ thiserror = "1.0.29"
 tui = { version = "0.16", default-features = false, features = ['crossterm'] }
 git2 = "0.13.23"
 progress_bar = "0.1.3"
+
+[features]
+default=["vendored-libgit2"]
+vendored-libgit2 = ["git2/vendored-libgit2"]


### PR DESCRIPTION
This commit fixes the issue: invalid version 0 on git_proxy_options; class=Invalid (3)) fixes #33 