### PR TITLE
chore: CI for scanning vulnerabilities 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  Vulnerability-test:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          
+        - name: Run Trivy vulnerability scanner in repo mode
+          uses: aquasecurity/trivy-action@master
+          with:
+            scan-type: 'fs'
+            ignore-unfixed: true
+            format: 'table'
+            output: 'trivy-results.sarif'
+            severity: 'LOW,MEDIUM,HIGH,CRITICAL'
+            exit-code: '1'
+            
+        - if: github.event_name == 'pull_request' && failure()
+          uses: actions/github-script@v5
+          with:
+            script: |
+              const fs = require('fs');
+              var data  = fs.readFileSync("trivy-results.sarif").toString();
+              var md = "```"
+              Trivyresult=""
+              Trivyresult=Trivyresult.concat(md,data,md);
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `
+                # Vulnerability Found!
+                ${Trivyresult}
+                `
+              })
+  
+  Upload-result:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          
+        - name: Run Trivy vulnerability scanner in repo mode
+          uses: aquasecurity/trivy-action@master
+          with:
+            scan-type: 'fs'
+            ignore-unfixed: true
+            format: 'template'
+            output: 'trivy-results.sarif'
+            template: '@/contrib/sarif.tpl'
+            severity: 'LOW,MEDIUM,HIGH,CRITICAL'
+      
+        - name: Upload Trivy scan results to GitHub Security-tab
+          uses: github/codeql-action/upload-sarif@v1
+          with:
+           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Added CI for scanning vulnerabilities and reports to github security tab #6 , in pull requests github actions bot will comment the vulnerabilities that is present in the PR repo 

Screenshots
![image](https://user-images.githubusercontent.com/72266283/136544999-8c2a773a-1788-4b51-bfc8-4f8ddb8e61b8.png)

Please do check the branch master and the [PRs](https://github.com/sanjaybaskaran01/templa-rs/pull/1) for working demo in my forked repository [here](https://github.com/sanjaybaskaran01/templa-rs)

Note:in [security-workflow branch](https://github.com/sanjaybaskaran01/templa-rs/tree/security-workflow) the severity unknown has been removed, opened PR from this branch since maintainers requested for ```severity: 'LOW,MEDIUM,HIGH,CRITICAL'```