### PR TITLE
chore: CI for scanning vulnerabilities

### DIFF
--- a/.github/workflows/CI_pull.yml
+++ b/.github/workflows/CI_pull.yml
@@ -1,0 +1,42 @@
+name: CI_pull
+
+on:
+  pull_request:
+    branches: [master]
+  
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  Vulnerability-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: "table"
+          output: "Trivy-table"
+          severity: "LOW,MEDIUM,HIGH,CRITICAL"
+          exit-code: "1"
+
+      - if: failure()
+        uses: actions/github-script@v5
+        with:
+          script: |
+            var data  = require('fs').readFileSync("Trivy-table").toString();
+            Trivyresult=""
+            Trivyresult=Trivyresult.concat("```",data,"```");
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `
+              # Vulnerability Found!
+              ${Trivyresult}
+              `
+            })

--- a/.github/workflows/CI_push.yml
+++ b/.github/workflows/CI_push.yml
@@ -1,0 +1,31 @@
+name: CI_push
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+
+  Upload-result:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          
+        - name: Run Trivy vulnerability scanner in repo mode
+          uses: aquasecurity/trivy-action@master
+          with:
+            scan-type: 'fs'
+            ignore-unfixed: true
+            format: 'template'
+            output: 'trivy-results.sarif'
+            template: '@/contrib/sarif.tpl'
+            severity: 'LOW,MEDIUM,HIGH,CRITICAL'
+      
+        - name: Upload Trivy scan results to GitHub Security-tab
+          uses: github/codeql-action/upload-sarif@v1
+          with:
+           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Added CI for scanning vulnerabilities and reports to github security tab #6 , in pull requests github actions bot will comment the vulnerabilities that is present in the PR repo

Screenshots

On pull requests if the forked repo contained vulnerable packages then the github-actions bot will comment the following..

![image](https://user-images.githubusercontent.com/72266283/136651178-c51f0217-2101-4b0a-bf05-8e0f0a43e3c6.png)

On pushes to the branch the following [action](https://github.com/sanjaybaskaran01/templa-rs/runs/3845748223?check_suite_focus=true) occurs:
![image](https://user-images.githubusercontent.com/72266283/136651263-396c348a-d47b-4016-bddd-308a8da34bd1.png)

It scans for vulnerable packages and updates in the github security tab incase any packages have been forcefully pushed.
![image](https://user-images.githubusercontent.com/72266283/136651366-4947751a-3c5f-4f0b-8b63-0864beaff8ed.png)
![image](https://user-images.githubusercontent.com/72266283/136651375-374d366e-12c6-4b2f-8287-3afb35f9c69c.png)


Check the forked [repo](https://github.com/sanjaybaskaran01/templa-rs) and the sample [PRs](https://github.com/sanjaybaskaran01/templa-rs/pulls)

Suggestion: In addition to this please enable dependabot too! :smile: 