### PR TITLE
Execute scrapes on a threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "clap",
  "crossterm",
  "git2",
+ "num_cpus",
  "openssl",
  "progress_bar",
  "reqwest",
@@ -1189,6 +1190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "threadpool",
  "tui",
 ]
 
@@ -1230,6 +1232,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,13 @@ edition = "2018"
 base64 = "0.13.0"
 clap = { version = "2.33.3", features = ["yaml"] }
 crossterm = "0.20"
+num_cpus = "1.13.0"
 openssl = { version = "0.10", features = ["vendored"] }  # for automated cross builds
 reqwest = { version = "0.11.4", features = ["blocking", "json"] }
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0.68"
 thiserror = "1.0.29"
+threadpool = "1.8.1"
 tui = { version = "0.16", default-features = false, features = ['crossterm'] }
 git2 = "0.13.23"
 progress_bar = "0.1.3"


### PR DESCRIPTION
Fixes #50 

Also included `num_cpus` to set the number of workers based on the user's CPU core count.